### PR TITLE
Update release-notes-8.2: mentioning essential QoS changes

### DIFF
--- a/release-notes-8.2
+++ b/release-notes-8.2
@@ -71,6 +71,7 @@ HTML header: <title>dCache 8.2 Release Notes</title>
 - pool group names can't start with `@` symbol
 - hard links on directories is not allowed
 - GET api/v1/bulk-requests has a new return value (see below)
+- The QoS API functionality now requires some services to operate. These are described in the dCache Book version 8.2.
 
 ## Acknowledgments
 


### PR DESCRIPTION
Some time ago I bumped into this, as described here: https://github.com/dCache/dcache/issues/6914

Mentioning this change under "incompatibilities", nicely on top of the document, might save others from running into the same issue.