### PR TITLE
Update release-notes-9.2

### DIFF
--- a/release-notes-9.2
+++ b/release-notes-9.2
@@ -72,6 +72,7 @@ HTML header: <title>dCache 9.2 Release Notes</title>
   the door publishes all available layout types
 - dropped reference count tracking for directory tags
 - dropped support of java options `chimera_soft_update` and `chimera_lazy_wcc` in favor of `chimera.attr-consistency` property
+- If upgrading from 8.2, be sure to read also the release notes for 9.0 and 9.1! Important changes are described there.
 
 ## Release 9.2.4
 


### PR DESCRIPTION
Warn people to read also the release notes for 9.0 and 9.1 if coming from 8.2. I guess otherwise some admins would break their cleaner without noticing... I think I would ;-)