### PR TITLE
Update release-notes-10.1: mention STAGE for macaroons

### DIFF
--- a/release-notes-10.1
+++ b/release-notes-10.1
@@ -68,6 +68,7 @@ HTML header: <title>dCache 10.1 Release Notes</title>
 ## Incompatibilities
 - starting with dcache-10.1.0 Java 17 is required for runtime.
 - Transfer managers database functionality has been removed.
+- When using macaroons, you now need the STAGE activity to be able to stage files from tape in the API.
 
 ## Acknowledgments
 


### PR DESCRIPTION
"When using macaroons, you now need the STAGE activity to be able to stage"

Related to issue https://github.com/dCache/dcache/issues/7665